### PR TITLE
Store referrer `UserId` in `Referrals` table to use during `Mutation.createChatDialog`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,16 @@ All user visible changes to this project will be documented in this file. This p
     - Promotion page:
         - Promotional percentage setting. ([#51])
     - User page:
-        - Promotional program information block ([#51])
+        - Promotional program information block. ([#51])
+
+### Changed
+
+- UI:
+    - Links statistics page:
+        - Promotional percentage displaying. ([#53])
 
 [#51]: /../../pull/51
+[#53]: /../../pull/53
 
 
 

--- a/lib/api/backend/graphql/mutation/chat/CreateDialog.graphql
+++ b/lib/api/backend/graphql/mutation/chat/CreateDialog.graphql
@@ -15,8 +15,14 @@
 # along with this program. If not, see
 # <https://www.gnu.org/licenses/agpl-3.0.html>.
 
-mutation CreateDialog($responderId: UserId!) {
-    createDialogChat(responderId: $responderId) {
+mutation CreateDialog(
+    $responderId: UserId!
+    $referrer: ReferralInput
+) {
+    createDialogChat(
+        responderId: $responderId
+        referrer: $referrer
+    ) {
         __typename
         ... on Chat {
             ...Chat

--- a/lib/domain/repository/chat.dart
+++ b/lib/domain/repository/chat.dart
@@ -230,6 +230,9 @@ abstract class AbstractChatRepository {
   /// Uses the specified [DirectLink] by the authenticated [MyUser] creating a
   /// new [Chat]-dialog or joining an existing [Chat]-group.
   Future<ChatId> useDirectLink(DirectLinkSlug slug);
+
+  /// Sets the [referrerId] to be the one who referred to the [forId] dialog.
+  Future<void> useReferral(UserId forId, UserId referrerId);
 }
 
 /// Unified reactive [Chat] entity with its [ChatItem]s.

--- a/lib/domain/service/chat.dart
+++ b/lib/domain/service/chat.dart
@@ -490,6 +490,12 @@ class ChatService extends Dependency {
     Log.debug('useDirectLink($slug)', '$runtimeType');
     return await _chatRepository.useDirectLink(slug);
   }
+
+  /// Sets the [referrerId] to be the one who referred to the [forId] dialog.
+  Future<void> useReferral(UserId forId, UserId referrerId) {
+    Log.debug('useReferral($forId, $referrerId)', '$runtimeType');
+    return _chatRepository.useReferral(forId, referrerId);
+  }
 }
 
 /// Extension adding a route from the [router] comparison with a [Chat].

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -56,6 +56,7 @@ import 'provider/drift/drift.dart';
 import 'provider/drift/geolocation.dart';
 import 'provider/drift/locks.dart';
 import 'provider/drift/my_user.dart';
+import 'provider/drift/referrals.dart';
 import 'provider/drift/secret.dart';
 import 'provider/drift/settings.dart';
 import 'provider/drift/skipped_version.dart';
@@ -280,6 +281,7 @@ Future<void> _runApp() async {
   Get.put(RefreshSecretDriftProvider(Get.find()));
   Get.put(CallKitCallsDriftProvider(Get.find()));
   Get.put(SlugDriftProvider(Get.find()));
+  Get.put(ReferralDriftProvider(Get.find()));
 
   if (!PlatformUtils.isWeb) {
     Get.put(WindowRectDriftProvider(Get.find()));

--- a/lib/provider/drift/drift.dart
+++ b/lib/provider/drift/drift.dart
@@ -51,6 +51,7 @@ import 'geolocation.dart';
 import 'locks.dart';
 import 'monolog.dart';
 import 'my_user.dart';
+import 'referrals.dart';
 import 'secret.dart';
 import 'session.dart';
 import 'settings.dart';
@@ -74,6 +75,7 @@ part 'drift.g.dart';
     GeoLocations,
     Locks,
     MyUsers,
+    Referrals,
     RefreshSecrets,
     Settings,
     SkippedVersions,

--- a/lib/provider/drift/referrals.dart
+++ b/lib/provider/drift/referrals.dart
@@ -33,7 +33,8 @@ class Referrals extends Table {
   TextColumn get referrerId => text()();
 }
 
-/// [DriftProviderBase] for manipulating the persisted [DirectLinkSlug]s.
+/// [DriftProviderBase] for manipulating the persisted [UserId]s as the
+/// referrals.
 class ReferralDriftProvider extends DriftProviderBase {
   ReferralDriftProvider(super.common);
 

--- a/lib/provider/drift/referrals.dart
+++ b/lib/provider/drift/referrals.dart
@@ -1,0 +1,84 @@
+// Copyright © 2025-2026 Ideas Networks Solutions S.A.,
+//                       <https://github.com/tapopa>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License v3.0 for
+// more details.
+//
+// You should have received a copy of the GNU Affero General Public License v3.0
+// along with this program. If not, see
+// <https://www.gnu.org/licenses/agpl-3.0.html>.
+
+import 'dart:async';
+
+import 'package:drift/drift.dart';
+
+import '/domain/model/user.dart';
+import '/util/log.dart';
+import 'drift.dart';
+
+/// [UserId]s stored as the referrals for [UserId].
+@DataClassName('ReferralRow')
+class Referrals extends Table {
+  @override
+  Set<Column> get primaryKey => {forId};
+
+  TextColumn get forId => text()();
+  TextColumn get referrerId => text()();
+}
+
+/// [DriftProviderBase] for manipulating the persisted [DirectLinkSlug]s.
+class ReferralDriftProvider extends DriftProviderBase {
+  ReferralDriftProvider(super.common);
+
+  /// Creates or updates the provided [referrerId] for the [forId] in the
+  /// database.
+  Future<void> upsert(UserId forId, UserId referrerId) async {
+    Log.debug('upsert($forId from $referrerId)', '$runtimeType');
+
+    await safe((db) async {
+      await db
+          .into(db.referrals)
+          .insert(
+            ReferralRow(forId: forId.val, referrerId: referrerId.val),
+            mode: InsertMode.insertOrReplace,
+          );
+    }, tag: 'slugs.upsert()');
+  }
+
+  /// Returns the [UserId] stored in the database, if any.
+  Future<UserId?> read(UserId forId) async {
+    Log.debug('read($forId)', '$runtimeType');
+
+    return await safe<UserId?>((db) async {
+      final stmt = db.select(db.referrals)
+        ..where((u) => u.forId.equals(forId.val));
+      final ReferralRow? row = await stmt.getSingleOrNull();
+      Log.debug('read($forId) -> $row', '$runtimeType');
+
+      if (row == null) {
+        return null;
+      }
+
+      return UserId(row.referrerId);
+    }, tag: 'slugs.read()');
+  }
+
+  /// Deletes the stored [UserId] from the database.
+  Future<void> delete(UserId forId) async {
+    Log.debug('delete($forId)', '$runtimeType');
+
+    await safe((db) async {
+      final stmt = db.delete(db.referrals)
+        ..where((e) => e.forId.equals(forId.val));
+
+      await stmt.go();
+    }, tag: 'slugs.delete()');
+  }
+}

--- a/lib/provider/gql/components/chat.dart
+++ b/lib/provider/gql/components/chat.dart
@@ -200,10 +200,19 @@ mixin ChatGraphQlMixin {
   ///
   /// Succeeds as no-op if a [Chat] with the given responder [User] exists
   /// already, and returns this [Chat].
-  Future<ChatMixin> createDialogChat(UserId responderId) async {
-    Log.debug('createDialogChat($responderId)', '$runtimeType');
+  Future<ChatMixin> createDialogChat(
+    UserId responderId, {
+    ReferralInput? referrer,
+  }) async {
+    Log.debug(
+      'createDialogChat($responderId, referral: $referrer)',
+      '$runtimeType',
+    );
 
-    final variables = CreateDialogArguments(responderId: responderId);
+    final variables = CreateDialogArguments(
+      responderId: responderId,
+      referrer: referrer,
+    );
     final QueryResult result = await client.mutate(
       MutationOptions(
         operationName: 'CreateDialog',

--- a/lib/routes.dart
+++ b/lib/routes.dart
@@ -672,6 +672,7 @@ class AppRouterDelegate extends RouterDelegate<RouteConfiguration>
                       Get.find(),
                       Get.find(),
                       Get.find(),
+                      Get.find(),
                       me: me,
                     ),
                   );
@@ -850,6 +851,7 @@ class AppRouterDelegate extends RouterDelegate<RouteConfiguration>
                       callRepository,
                       Get.find(),
                       userRepository,
+                      Get.find(),
                       Get.find(),
                       Get.find(),
                       Get.find(),
@@ -1094,6 +1096,7 @@ class AppRouterDelegate extends RouterDelegate<RouteConfiguration>
             userRepository,
             versionProvider,
             monologProvider,
+            Get.find(),
             Get.find(),
             me: me,
           );
@@ -1343,8 +1346,10 @@ extension RouteLinks on RouterState {
   /// Changes router location to the [Routes.user] page.
   ///
   /// If [push] is `true`, then location is pushed to the router location stack.
-  void user(UserId id, {bool push = false}) =>
-      (push ? this.push : go)('${Routes.user}/$id');
+  void user(UserId id, {bool push = false, UserId? referrerId}) {
+    (push ? this.push : go)('${Routes.user}/$id');
+    arguments = {'referrerId': referrerId};
+  }
 
   /// Changes router location to the [Routes.chats] page.
   ///
@@ -1355,6 +1360,7 @@ extension RouteLinks on RouterState {
     ChatItemId? itemId,
     DirectLinkSlug? link,
     bool search = false,
+    UserId? referrerId,
   }) {
     switch (mode) {
       case RouteAs.insteadOfLast:
@@ -1371,7 +1377,12 @@ extension RouteLinks on RouterState {
         break;
     }
 
-    arguments = {'itemId': itemId, 'link': link, 'search': search};
+    arguments = {
+      'itemId': itemId,
+      'link': link,
+      'search': search,
+      'referrerId': referrerId,
+    };
 
     // TODO: Might not be the best thing to do it.
     if (search) {

--- a/lib/store/chat.dart
+++ b/lib/store/chat.dart
@@ -58,6 +58,7 @@ import '/provider/drift/chat_member.dart';
 import '/provider/drift/chat.dart';
 import '/provider/drift/draft.dart';
 import '/provider/drift/monolog.dart';
+import '/provider/drift/referrals.dart';
 import '/provider/drift/slugs.dart';
 import '/provider/drift/version.dart';
 import '/provider/gql/exceptions.dart'
@@ -121,7 +122,8 @@ class ChatRepository extends IdentityDependency
     this._userRepo,
     this._sessionLocal,
     this._monologLocal,
-    this._slugProvider, {
+    this._slugProvider,
+    this._referralProvider, {
     required super.me,
   });
 
@@ -237,6 +239,9 @@ class ChatRepository extends IdentityDependency
 
   /// [SlugDriftProvider] for retrieving affiliate [DirectLinkSlug].
   final SlugDriftProvider _slugProvider;
+
+  /// [ReferralDriftProvider] for storing and retrieving referral [UserId]s.
+  final ReferralDriftProvider _referralProvider;
 
   /// [CombinedPagination] loading [chats] with pagination.
   CombinedPagination<DtoChat, ChatId>? _pagination;
@@ -575,9 +580,29 @@ class ChatRepository extends IdentityDependency
         }
       }
 
+      UserId? referrerId;
+
+      try {
+        referrerId = await _referralProvider.read(userId);
+        Log.debug(
+          'ensureRemoteDialog() -> using `referrerId`: $referrerId',
+          '$runtimeType',
+        );
+      } catch (e) {
+        Log.warning(
+          'ensureRemoteDialog() -> unable to read referrer due to: $e',
+          '$runtimeType',
+        );
+      }
+
       try {
         final ChatData chat = _chat(
-          await _graphQlProvider.createDialogChat(chatId.userId),
+          await _graphQlProvider.createDialogChat(
+            chatId.userId,
+            referrer: referrerId == null
+                ? null
+                : ReferralInput(userId: referrerId),
+          ),
         );
 
         if (chat.chat.value.isSupport) {
@@ -2023,6 +2048,11 @@ class ChatRepository extends IdentityDependency
     );
 
     return response.chat.id;
+  }
+
+  @override
+  Future<void> useReferral(UserId forId, UserId referrerId) async {
+    await _referralProvider.upsert(forId, referrerId);
   }
 
   /// Constructs a [ChatEvent] from the [ChatEventsVersionedMixin$Events].

--- a/lib/ui/page/home/page/chat/controller.dart
+++ b/lib/ui/page/home/page/chat/controller.dart
@@ -128,6 +128,7 @@ class ChatController extends GetxController with IdentityAware {
     this.itemId,
     this.onContext,
     bool search = false,
+    this.referrerId,
   }) {
     if (search) {
       toggleSearch(true);
@@ -254,6 +255,9 @@ class ChatController extends GetxController with IdentityAware {
 
   /// Indicator whether [search]ing is being active right now.
   final RxBool searching = RxBool(false);
+
+  /// [UserId] who triggered this [ChatView] to be opened.
+  final UserId? referrerId;
 
   /// Subscription for [Paginated.updates] of the [search].
   StreamSubscription? _searchSubscription;
@@ -1152,6 +1156,19 @@ class ChatController extends GetxController with IdentityAware {
         unreadMessages = chat!.chat.value.unreadCount;
 
         send.toggleLogs(isMonolog || isSupport);
+
+        if (referrerId != null) {
+          final UserId? userId = chat?.chat.value.isDialog == true
+              ? chat?.chat.value.members
+                    .firstWhereOrNull((e) => e.user.id != me)
+                    ?.user
+                    .id
+              : null;
+
+          if (userId != null) {
+            _chatService.useReferral(userId, referrerId!);
+          }
+        }
 
         await chat!.ensureDraft();
         final ChatMessage? draft = chat!.draft.value;

--- a/lib/ui/page/home/page/chat/view.dart
+++ b/lib/ui/page/home/page/chat/view.dart
@@ -82,7 +82,13 @@ import 'widget/with_global_key.dart';
 
 /// View of the [Routes.chats] page.
 class ChatView extends StatelessWidget {
-  const ChatView(this.id, {super.key, this.itemId, this.search = false});
+  const ChatView(
+    this.id, {
+    super.key,
+    this.itemId,
+    this.search = false,
+    this.referrerId,
+  });
 
   /// ID of this [Chat].
   final ChatId id;
@@ -92,6 +98,9 @@ class ChatView extends StatelessWidget {
 
   /// Indicator whether searching mode should be enabled by default or not.
   final bool search;
+
+  /// [UserId] who triggered this [ChatView] to be opened.
+  final UserId? referrerId;
 
   @override
   Widget build(BuildContext context) {
@@ -115,6 +124,7 @@ class ChatView extends StatelessWidget {
         itemId: itemId,
         onContext: () => context,
         search: search,
+        referrerId: referrerId,
       ),
       tag: id.val,
       global: !Get.isRegistered<ChatController>(tag: id.val),
@@ -893,7 +903,13 @@ class ChatView extends StatelessWidget {
                       chatId = c.monolog;
                     }
 
-                    router.chat(chatId, mode: RouteAs.push);
+                    router.chat(
+                      chatId,
+                      mode: RouteAs.push,
+                      referrerId: e.value.author.id == c.me
+                          ? null
+                          : e.value.author.id,
+                    );
                   },
                   onDragging: (e) => c.isDraggingItem.value = e,
                 ),
@@ -1053,6 +1069,9 @@ class ChatView extends StatelessWidget {
                           item.quote.original!.chatId,
                           itemId: item.quote.original!.id,
                           mode: RouteAs.push,
+                          referrerId: item.quote.original?.author.id == c.me
+                              ? null
+                              : item.quote.original?.author.id,
                         );
                       }
                     }

--- a/lib/ui/page/home/page/chat/widget/chat_forward.dart
+++ b/lib/ui/page/home/page/chat/widget/chat_forward.dart
@@ -342,8 +342,11 @@ class _ChatForwardWidgetState extends State<ChatForwardWidget> {
                             TextSpan(
                               text: widget.user?.title() ?? 'dot'.l10n * 3,
                               recognizer: TapGestureRecognizer()
-                                ..onTap = () =>
-                                    router.user(widget.authorId, push: true),
+                                ..onTap = () => router.user(
+                                  widget.authorId,
+                                  push: true,
+                                  referrerId: _fromMe ? null : widget.authorId,
+                                ),
                             ),
                             selectable:
                                 widget.selectable &&
@@ -443,7 +446,11 @@ class _ChatForwardWidgetState extends State<ChatForwardWidget> {
                         style.colors.userColors.length];
 
               return WidgetButton(
-                onPressed: () => router.user(quote.author, push: true),
+                onPressed: () => router.user(
+                  quote.author,
+                  push: true,
+                  referrerId: _fromMe ? null : widget.authorId,
+                ),
                 child: Row(
                   children: [
                     SizedBox(width: 6),
@@ -744,8 +751,11 @@ class _ChatForwardWidgetState extends State<ChatForwardWidget> {
                       TextSpan(
                         text: widget.user?.title() ?? 'dot'.l10n * 3,
                         recognizer: TapGestureRecognizer()
-                          ..onTap = () =>
-                              router.user(widget.authorId, push: true),
+                          ..onTap = () => router.user(
+                            widget.authorId,
+                            push: true,
+                            referrerId: _fromMe ? null : widget.authorId,
+                          ),
                       ),
                       selectable:
                           widget.selectable &&
@@ -1007,7 +1017,11 @@ class _ChatForwardWidgetState extends State<ChatForwardWidget> {
                   child: widget.withAvatar
                       ? InkWell(
                           customBorder: const CircleBorder(),
-                          onTap: () => router.user(widget.authorId, push: true),
+                          onTap: () => router.user(
+                            widget.authorId,
+                            push: true,
+                            referrerId: _fromMe ? null : widget.authorId,
+                          ),
                           child: AvatarWidget.fromRxUser(
                             widget.user,
                             radius: avatarRadius,
@@ -1307,9 +1321,10 @@ class _ChatForwardWidgetState extends State<ChatForwardWidget> {
         if (string?.isNotEmpty == true) {
           _text[forward.value.id] = string!.parseLinks(
             _recognizers,
-            router.context == null
+            style: router.context == null
                 ? null
                 : Theme.of(router.context!).style.linkStyle,
+            authorId: _fromMe ? null : widget.authorId,
           );
         }
       }
@@ -1321,9 +1336,10 @@ class _ChatForwardWidgetState extends State<ChatForwardWidget> {
       if (string?.isNotEmpty == true) {
         _text[item.id] = string!.parseLinks(
           _recognizers,
-          router.context == null
+          style: router.context == null
               ? null
               : Theme.of(router.context!).style.linkStyle,
+          authorId: _fromMe ? null : widget.authorId,
         );
       }
     }

--- a/lib/ui/page/home/page/chat/widget/chat_item.dart
+++ b/lib/ui/page/home/page/chat/widget/chat_item.dart
@@ -1807,7 +1807,7 @@ class _ChatItemWidgetState extends State<ChatItemWidget> {
     }
   }
 
-  /// Populates the [_text] with the [ChatMessage.text] of the provided [item]
+  /// Populates the [_text] with the [ChatMessage.text] of the provided [msg]
   /// parsed through a [LinkParsingExtension.parseLinks] method.
   void _populateSpans(ChatItem msg) {
     if (msg is ChatMessage) {
@@ -1822,9 +1822,10 @@ class _ChatItemWidgetState extends State<ChatItemWidget> {
       } else {
         _text = string?.parseLinks(
           _recognizers,
-          router.context == null
+          style: router.context == null
               ? null
               : Theme.of(router.context!).style.linkStyle,
+          authorId: _fromMe ? null : msg.author.id,
         );
       }
     } else if (msg is ChatForward) {
@@ -2119,9 +2120,10 @@ extension LinkParsingExtension on String {
   /// [recognizers] are [TapGestureRecognizer]s constructed, so ensure to
   /// dispose them properly.
   TextSpan parseLinks(
-    List<TapGestureRecognizer> recognizers, [
+    List<TapGestureRecognizer> recognizers, {
     TextStyle? style,
-  ]) {
+    UserId? authorId,
+  }) {
     final Iterable<RegExpMatch> matches = [
       ..._regex.allMatches(this),
       ...UserNum.sourceExp.allMatches(this),
@@ -2172,7 +2174,11 @@ extension LinkParsingExtension on String {
               if (isNum) {
                 final UserNum? parsed = UserNum.tryParse(link);
                 if (parsed != null) {
-                  return router.chat(ChatId(link), mode: RouteAs.push);
+                  return router.chat(
+                    ChatId(link),
+                    mode: RouteAs.push,
+                    referrerId: authorId,
+                  );
                 }
               } else if (link.isEmail) {
                 uri = Uri(scheme: 'mailto', path: link);

--- a/lib/ui/page/home/page/management/controller.dart
+++ b/lib/ui/page/home/page/management/controller.dart
@@ -21,12 +21,15 @@ import 'package:flutter/widgets.dart';
 import 'package:get/get.dart';
 
 import '/domain/model/link.dart';
+import '/domain/model/monetization_settings.dart';
 import '/domain/model/user.dart';
 import '/domain/repository/paginated.dart';
 import '/domain/repository/user.dart';
 import '/domain/service/auth.dart';
 import '/domain/service/link.dart';
+import '/domain/service/partner.dart';
 import '/domain/service/user.dart';
+import '/util/obs/obs.dart';
 
 /// Possible [DirectLink] columns to display in a [TableView].
 enum LinkColumn {
@@ -43,7 +46,12 @@ enum LinkColumn {
 
 /// Controller of a [ManagementView].
 class ManagementController extends GetxController {
-  ManagementController(this._linkService, this._userService, this._authService);
+  ManagementController(
+    this._linkService,
+    this._userService,
+    this._authService,
+    this._partnerService,
+  );
 
   /// [Paginated] containing the [DirectLink]s of the current [MyUser].
   late final Paginated<DirectLinkSlug, DirectLink> links;
@@ -75,11 +83,22 @@ class ManagementController extends GetxController {
   /// [AuthService] used to retrieve the [me].
   final AuthService _authService;
 
+  /// [PartnerService] used to retrieve the [MonetizationSettings].
+  final PartnerService _partnerService;
+
+  StreamSubscription? _linksSubscription;
+  final Map<UserId, StreamSubscription> _monetizationSubscriptions = {};
+
   /// Returns the [UserId] of the currently authenticated [MyUser].
   UserId? get me => _authService.userId;
 
   /// Returns the total amount of [DirectLink] created by [MyUser].
   RxInt get total => _linkService.total;
+
+  /// Returns the [MonetizationSettings] that the [UserId]s have for our
+  /// [MyUser].
+  RxMap<UserId, Rx<MonetizationSettings>> get monetization =>
+      _partnerService.monetization;
 
   @override
   void onInit() {
@@ -88,6 +107,20 @@ class ManagementController extends GetxController {
 
     links = _linkService.links();
     links.ensureInitialized();
+    links.values.forEach(_handle);
+
+    _linksSubscription = links.items.changes.listen((e) {
+      switch (e.op) {
+        case OperationKind.added:
+        case OperationKind.updated:
+          _handle(e.value);
+          break;
+
+        case OperationKind.removed:
+          // No-op.
+          break;
+      }
+    });
 
     super.onInit();
   }
@@ -96,6 +129,13 @@ class ManagementController extends GetxController {
   void onClose() {
     vertical.removeListener(_scrollListener);
     listController.removeListener(_listListener);
+
+    _linksSubscription?.cancel();
+    for (var e in _monetizationSubscriptions.values) {
+      e.cancel();
+    }
+    _monetizationSubscriptions.clear();
+
     super.onClose();
   }
 
@@ -133,6 +173,23 @@ class ManagementController extends GetxController {
         if (links.hasNext.value && !links.nextLoading.value) {
           await links.next();
         }
+      }
+    }
+  }
+
+  /// Adds a [StreamSubscription] to [_monetizationSubscriptions] listening for
+  /// updates of [User] this [link] leads to, if any.
+  void _handle(DirectLink? link) {
+    if (link == null) {
+      return;
+    }
+
+    final location = link.location;
+    if (location is DirectLinkLocationUser) {
+      if (!_monetizationSubscriptions.containsKey(location.responder)) {
+        _monetizationSubscriptions[location.responder] = _partnerService
+            .updatesFor(location.responder)
+            .listen((_) {});
       }
     }
   }

--- a/lib/ui/page/home/page/management/view.dart
+++ b/lib/ui/page/home/page/management/view.dart
@@ -19,9 +19,9 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:share_plus/share_plus.dart';
 
-import '../../../../../domain/model/monetization_settings.dart';
 import '/config.dart';
 import '/domain/model/link.dart';
+import '/domain/model/monetization_settings.dart';
 import '/domain/model/price.dart';
 import '/domain/repository/user.dart';
 import '/l10n/l10n.dart';

--- a/lib/ui/page/home/page/management/view.dart
+++ b/lib/ui/page/home/page/management/view.dart
@@ -19,6 +19,7 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:share_plus/share_plus.dart';
 
+import '../../../../../domain/model/monetization_settings.dart';
 import '/config.dart';
 import '/domain/model/link.dart';
 import '/domain/model/price.dart';
@@ -54,7 +55,12 @@ class ManagementView extends StatelessWidget {
     final style = Theme.of(context).style;
 
     return GetBuilder(
-      init: ManagementController(Get.find(), Get.find(), Get.find()),
+      init: ManagementController(
+        Get.find(),
+        Get.find(),
+        Get.find(),
+        Get.find(),
+      ),
       builder: (ManagementController c) {
         return Scaffold(
           appBar: CustomAppBar(
@@ -225,7 +231,25 @@ class ManagementView extends StatelessWidget {
         identifier: column.name,
         width: 2,
         header: () => Text('label_promotional_percentage'.l10n),
-        builder: (e) => Text(e.isEnabled ? '0%' : '---'),
+        builder: (e) {
+          if (e.isEnabled) {
+            final DirectLinkLocation location = e.location;
+            if (location is DirectLinkLocationUser) {
+              return Obx(() {
+                final Rx<MonetizationSettings>? settings =
+                    c.monetization[location.responder];
+
+                if (settings != null) {
+                  return Text('${settings.value.referral?.fee?.val ?? 0}%');
+                }
+
+                return Text('---');
+              });
+            }
+          }
+
+          return Text('---');
+        },
       ),
       LinkColumn.income => TableBuilder(
         key: c.keys[column],

--- a/lib/ui/page/home/page/user/controller.dart
+++ b/lib/ui/page/home/page/user/controller.dart
@@ -68,8 +68,13 @@ class UserController extends GetxController {
     this._chatService,
     this._callService,
     this._partnerService,
-    this._linkService,
-  );
+    this._linkService, {
+    UserId? referrerId,
+  }) {
+    if (referrerId != null) {
+      _chatService.useReferral(id, referrerId);
+    }
+  }
 
   /// ID of the [User] this [UserController] represents.
   final UserId id;

--- a/lib/ui/page/home/page/user/view.dart
+++ b/lib/ui/page/home/page/user/view.dart
@@ -64,10 +64,13 @@ import 'widget/quick_button.dart';
 
 /// View of the [Routes.user] page.
 class UserView extends StatelessWidget {
-  const UserView(this.id, {super.key});
+  const UserView(this.id, {super.key, this.referrerId});
 
   /// ID of the [User] this [UserView] represents.
   final UserId id;
+
+  /// [UserId] who triggered this [ChatView] to be opened.
+  final UserId? referrerId;
 
   @override
   Widget build(BuildContext context) {
@@ -79,6 +82,7 @@ class UserView extends StatelessWidget {
         Get.find(),
         Get.find(),
         Get.find(),
+        referrerId: referrerId,
       ),
       tag: id.val,
       global: !Get.isRegistered<UserController>(tag: id.val),

--- a/lib/ui/page/home/router.dart
+++ b/lib/ui/page/home/router.dart
@@ -99,6 +99,7 @@ class HomeRouterDelegate extends RouterDelegate<RouteConfiguration>
               ChatId(id),
               itemId: router.arguments?['itemId'] as ChatItemId?,
               search: router.arguments?['search'] == true,
+              referrerId: router.arguments?['referrerId'] as UserId?,
             ),
           ),
         );
@@ -117,7 +118,10 @@ class HomeRouterDelegate extends RouterDelegate<RouteConfiguration>
           CustomPage(
             key: ValueKey('UserPage$id'),
             name: '${Routes.user}/$id',
-            child: UserView(UserId(id)),
+            child: UserView(
+              UserId(id),
+              referrerId: router.arguments?['referrerId'] as UserId?,
+            ),
           ),
         );
       } else if (route.startsWith(Routes.erase)) {

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -120,7 +120,7 @@ PODS:
   - screen_retriever_macos (0.0.1):
     - FlutterMacOS
   - Sentry/HybridSDK (8.58.0)
-  - sentry_flutter (9.15.0):
+  - sentry_flutter (9.16.1):
     - Flutter
     - FlutterMacOS
     - Sentry/HybridSDK (= 8.58.0)
@@ -301,7 +301,7 @@ SPEC CHECKSUMS:
   screen_brightness_macos: 2a3ee243f8051c340381e8e51bcedced8360f421
   screen_retriever_macos: 452e51764a9e1cdb74b3c541238795849f21557f
   Sentry: d587a8fe91ca13503ecd69a1905f3e8a0fcf61be
-  sentry_flutter: 8939e491bc1511868118c96cae47d945e6f69798
+  sentry_flutter: 1fbec4ff50a6b08d7b22030bb8ec798e75afd71c
   share_plus: 510bf0af1a42cd602274b4629920c9649c52f4cc
   shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
   super_native_extensions: c2795d6d9aedf4a79fae25cb6160b71b50549189

--- a/test/unit/call_test.dart
+++ b/test/unit/call_test.dart
@@ -48,6 +48,7 @@ import 'package:messenger/provider/drift/drift.dart';
 import 'package:messenger/provider/drift/locks.dart';
 import 'package:messenger/provider/drift/monolog.dart';
 import 'package:messenger/provider/drift/my_user.dart';
+import 'package:messenger/provider/drift/referrals.dart';
 import 'package:messenger/provider/drift/secret.dart';
 import 'package:messenger/provider/drift/settings.dart';
 import 'package:messenger/provider/drift/slugs.dart';
@@ -98,6 +99,7 @@ void main() async {
     final locksProvider = Get.put(LockDriftProvider(common));
     final secretsProvider = Get.put(RefreshSecretDriftProvider(common));
     final slugProvider = Get.put(SlugDriftProvider(common));
+    final referralProvider = Get.put(ReferralDriftProvider(common));
 
     await accountProvider.upsert(const UserId('me'));
     await credentialsProvider.upsert(
@@ -203,6 +205,7 @@ void main() async {
         sessionProvider,
         monologProvider,
         slugProvider,
+        referralProvider,
         me: const UserId('me'),
       ),
     );
@@ -330,6 +333,7 @@ void main() async {
     final locksProvider = Get.put(LockDriftProvider(common));
     final secretsProvider = Get.put(RefreshSecretDriftProvider(common));
     final slugProvider = Get.put(SlugDriftProvider(common));
+    final referralProvider = Get.put(ReferralDriftProvider(common));
 
     final graphQlProvider = _FakeGraphQlProvider();
     Get.put<GraphQlProvider>(graphQlProvider);
@@ -388,6 +392,7 @@ void main() async {
         sessionProvider,
         monologProvider,
         slugProvider,
+        referralProvider,
         me: const UserId('me'),
       ),
     );
@@ -453,6 +458,7 @@ void main() async {
     final locksProvider = Get.put(LockDriftProvider(common));
     final secretsProvider = Get.put(RefreshSecretDriftProvider(common));
     final slugProvider = Get.put(SlugDriftProvider(common));
+    final referralProvider = Get.put(ReferralDriftProvider(common));
 
     final graphQlProvider = _FakeGraphQlProvider();
 
@@ -510,6 +516,7 @@ void main() async {
         sessionProvider,
         monologProvider,
         slugProvider,
+        referralProvider,
         me: const UserId('me'),
       ),
     );

--- a/test/unit/chat_attachment_test.dart
+++ b/test/unit/chat_attachment_test.dart
@@ -47,6 +47,7 @@ import 'package:messenger/provider/drift/drift.dart';
 import 'package:messenger/provider/drift/locks.dart';
 import 'package:messenger/provider/drift/monolog.dart';
 import 'package:messenger/provider/drift/my_user.dart';
+import 'package:messenger/provider/drift/referrals.dart';
 import 'package:messenger/provider/drift/secret.dart';
 import 'package:messenger/provider/drift/settings.dart';
 import 'package:messenger/provider/drift/slugs.dart';
@@ -100,6 +101,7 @@ void main() async {
   final locksProvider = Get.put(LockDriftProvider(common));
   final secretsProvider = Get.put(RefreshSecretDriftProvider(common));
   final slugProvider = Get.put(SlugDriftProvider(common));
+  final referralProvider = Get.put(ReferralDriftProvider(common));
 
   when(
     graphQlProvider.recentChatsTopEvents(3),
@@ -242,6 +244,7 @@ void main() async {
             sessionProvider,
             monologProvider,
             slugProvider,
+            referralProvider,
             me: const UserId('me'),
           ),
         );
@@ -344,6 +347,7 @@ void main() async {
             sessionProvider,
             monologProvider,
             slugProvider,
+            referralProvider,
             me: const UserId('me'),
           ),
         );
@@ -460,6 +464,7 @@ void main() async {
               sessionProvider,
               monologProvider,
               slugProvider,
+              referralProvider,
               me: const UserId('me'),
             ),
           );

--- a/test/unit/chat_avatar_test.dart
+++ b/test/unit/chat_avatar_test.dart
@@ -43,6 +43,7 @@ import 'package:messenger/provider/drift/drift.dart';
 import 'package:messenger/provider/drift/locks.dart';
 import 'package:messenger/provider/drift/monolog.dart';
 import 'package:messenger/provider/drift/my_user.dart';
+import 'package:messenger/provider/drift/referrals.dart';
 import 'package:messenger/provider/drift/secret.dart';
 import 'package:messenger/provider/drift/settings.dart';
 import 'package:messenger/provider/drift/slugs.dart';
@@ -97,6 +98,7 @@ void main() async {
   final locksProvider = Get.put(LockDriftProvider(common));
   final secretsProvider = Get.put(RefreshSecretDriftProvider(common));
   final slugProvider = Get.put(SlugDriftProvider(common));
+  final referralProvider = Get.put(ReferralDriftProvider(common));
 
   when(
     graphQlProvider.incomingCallsTopEvents(3),
@@ -214,6 +216,7 @@ void main() async {
       sessionProvider,
       monologProvider,
       slugProvider,
+      referralProvider,
       me: const UserId('me'),
     );
 
@@ -313,6 +316,7 @@ void main() async {
       sessionProvider,
       monologProvider,
       slugProvider,
+      referralProvider,
       me: const UserId('me'),
     );
 

--- a/test/unit/chat_delete_message_test.dart
+++ b/test/unit/chat_delete_message_test.dart
@@ -45,6 +45,7 @@ import 'package:messenger/provider/drift/drift.dart';
 import 'package:messenger/provider/drift/locks.dart';
 import 'package:messenger/provider/drift/monolog.dart';
 import 'package:messenger/provider/drift/my_user.dart';
+import 'package:messenger/provider/drift/referrals.dart';
 import 'package:messenger/provider/drift/secret.dart';
 import 'package:messenger/provider/drift/settings.dart';
 import 'package:messenger/provider/drift/slugs.dart';
@@ -122,6 +123,7 @@ void main() async {
   final locksProvider = Get.put(LockDriftProvider(common));
   final secretsProvider = Get.put(RefreshSecretDriftProvider(common));
   final slugProvider = Get.put(SlugDriftProvider(common));
+  final referralProvider = Get.put(ReferralDriftProvider(common));
 
   var chatData = {
     'id': '0d72d245-8425-467a-9ebd-082d4f47850b',
@@ -284,6 +286,7 @@ void main() async {
       sessionProvider,
       monologProvider,
       slugProvider,
+      referralProvider,
       me: const UserId('me'),
     ),
   );

--- a/test/unit/chat_edit_message_test.dart
+++ b/test/unit/chat_edit_message_test.dart
@@ -45,6 +45,7 @@ import 'package:messenger/provider/drift/drift.dart';
 import 'package:messenger/provider/drift/locks.dart';
 import 'package:messenger/provider/drift/monolog.dart';
 import 'package:messenger/provider/drift/my_user.dart';
+import 'package:messenger/provider/drift/referrals.dart';
 import 'package:messenger/provider/drift/secret.dart';
 import 'package:messenger/provider/drift/settings.dart';
 import 'package:messenger/provider/drift/slugs.dart';
@@ -99,6 +100,7 @@ void main() async {
   final locksProvider = Get.put(LockDriftProvider(common));
   final secretsProvider = Get.put(RefreshSecretDriftProvider(common));
   final slugProvider = Get.put(SlugDriftProvider(common));
+  final referralProvider = Get.put(ReferralDriftProvider(common));
 
   when(graphQlProvider.disconnect()).thenAnswer((_) => () {});
 
@@ -269,6 +271,7 @@ void main() async {
             sessionProvider,
             monologProvider,
             slugProvider,
+            referralProvider,
             me: const UserId('me'),
           ),
         );
@@ -368,6 +371,7 @@ void main() async {
               sessionProvider,
               monologProvider,
               slugProvider,
+              referralProvider,
               me: const UserId('me'),
             ),
           );

--- a/test/unit/chat_hide_test.dart
+++ b/test/unit/chat_hide_test.dart
@@ -43,6 +43,7 @@ import 'package:messenger/provider/drift/geolocation.dart';
 import 'package:messenger/provider/drift/locks.dart';
 import 'package:messenger/provider/drift/monolog.dart';
 import 'package:messenger/provider/drift/my_user.dart';
+import 'package:messenger/provider/drift/referrals.dart';
 import 'package:messenger/provider/drift/secret.dart';
 import 'package:messenger/provider/drift/session.dart';
 import 'package:messenger/provider/drift/settings.dart';
@@ -103,6 +104,7 @@ void main() async {
   final locksProvider = Get.put(LockDriftProvider(common));
   final secretsProvider = Get.put(RefreshSecretDriftProvider(common));
   final slugProvider = Get.put(SlugDriftProvider(common));
+  final referralProvider = Get.put(ReferralDriftProvider(common));
 
   var chatData = {
     'id': '0d72d245-8425-467a-9ebd-082d4f47850b',
@@ -305,6 +307,7 @@ void main() async {
         versionProvider,
         monologProvider,
         slugProvider,
+        referralProvider,
         me: const UserId('me'),
       ),
     );
@@ -385,6 +388,7 @@ void main() async {
         versionProvider,
         monologProvider,
         slugProvider,
+        referralProvider,
         me: const UserId('me'),
       ),
     );

--- a/test/unit/chat_leave_test.dart
+++ b/test/unit/chat_leave_test.dart
@@ -41,6 +41,7 @@ import 'package:messenger/provider/drift/drift.dart';
 import 'package:messenger/provider/drift/locks.dart';
 import 'package:messenger/provider/drift/monolog.dart';
 import 'package:messenger/provider/drift/my_user.dart';
+import 'package:messenger/provider/drift/referrals.dart';
 import 'package:messenger/provider/drift/secret.dart';
 import 'package:messenger/provider/drift/settings.dart';
 import 'package:messenger/provider/drift/slugs.dart';
@@ -95,6 +96,7 @@ void main() async {
   final locksProvider = Get.put(LockDriftProvider(common));
   final secretsProvider = Get.put(RefreshSecretDriftProvider(common));
   final slugProvider = Get.put(SlugDriftProvider(common));
+  final referralProvider = Get.put(ReferralDriftProvider(common));
 
   var chatData = {
     'id': '0d72d245-8425-467a-9ebd-082d4f47850b',
@@ -248,6 +250,7 @@ void main() async {
         sessionProvider,
         monologProvider,
         slugProvider,
+        referralProvider,
         me: const UserId('me'),
       ),
     );

--- a/test/unit/chat_members_test.dart
+++ b/test/unit/chat_members_test.dart
@@ -41,6 +41,7 @@ import 'package:messenger/provider/drift/drift.dart';
 import 'package:messenger/provider/drift/locks.dart';
 import 'package:messenger/provider/drift/monolog.dart';
 import 'package:messenger/provider/drift/my_user.dart';
+import 'package:messenger/provider/drift/referrals.dart';
 import 'package:messenger/provider/drift/secret.dart';
 import 'package:messenger/provider/drift/settings.dart';
 import 'package:messenger/provider/drift/slugs.dart';
@@ -271,6 +272,7 @@ void main() async {
     final locksProvider = Get.put(LockDriftProvider(common));
     final secretsProvider = Get.put(RefreshSecretDriftProvider(common));
     final slugProvider = Get.put(SlugDriftProvider(common));
+    final referralProvider = Get.put(ReferralDriftProvider(common));
 
     final AbstractSettingsRepository settingsRepository = Get.put(
       SettingsRepository(
@@ -327,6 +329,7 @@ void main() async {
             sessionProvider,
             monologProvider,
             slugProvider,
+            referralProvider,
             me: const UserId('me'),
           ),
         );

--- a/test/unit/chat_read_test.dart
+++ b/test/unit/chat_read_test.dart
@@ -42,6 +42,7 @@ import 'package:messenger/provider/drift/drift.dart';
 import 'package:messenger/provider/drift/locks.dart';
 import 'package:messenger/provider/drift/monolog.dart';
 import 'package:messenger/provider/drift/my_user.dart';
+import 'package:messenger/provider/drift/referrals.dart';
 import 'package:messenger/provider/drift/secret.dart';
 import 'package:messenger/provider/drift/settings.dart';
 import 'package:messenger/provider/drift/slugs.dart';
@@ -83,6 +84,7 @@ void main() async {
   final locksProvider = Get.put(LockDriftProvider(common));
   final secretsProvider = Get.put(RefreshSecretDriftProvider(common));
   final slugProvider = Get.put(SlugDriftProvider(common));
+  final referralProvider = Get.put(ReferralDriftProvider(common));
 
   var chatData = {
     'id': '0d72d245-8425-467a-9ebd-082d4f47850b',
@@ -308,6 +310,7 @@ void main() async {
         sessionProvider,
         monologProvider,
         slugProvider,
+        referralProvider,
         me: const UserId('me'),
       ),
     );
@@ -415,6 +418,7 @@ void main() async {
         sessionProvider,
         monologProvider,
         slugProvider,
+        referralProvider,
         me: const UserId('me'),
       ),
     );

--- a/test/unit/chat_rename_test.dart
+++ b/test/unit/chat_rename_test.dart
@@ -41,6 +41,7 @@ import 'package:messenger/provider/drift/drift.dart';
 import 'package:messenger/provider/drift/locks.dart';
 import 'package:messenger/provider/drift/monolog.dart';
 import 'package:messenger/provider/drift/my_user.dart';
+import 'package:messenger/provider/drift/referrals.dart';
 import 'package:messenger/provider/drift/secret.dart';
 import 'package:messenger/provider/drift/settings.dart';
 import 'package:messenger/provider/drift/slugs.dart';
@@ -95,6 +96,7 @@ void main() async {
   final locksProvider = Get.put(LockDriftProvider(common));
   final secretsProvider = Get.put(RefreshSecretDriftProvider(common));
   final slugProvider = Get.put(SlugDriftProvider(common));
+  final referralProvider = Get.put(ReferralDriftProvider(common));
 
   var chatData = {
     'id': '0d72d245-8425-467a-9ebd-082d4f47850b',
@@ -303,6 +305,7 @@ void main() async {
         sessionProvider,
         monologProvider,
         slugProvider,
+        referralProvider,
         me: const UserId('me'),
       ),
     );
@@ -366,6 +369,7 @@ void main() async {
           sessionProvider,
           monologProvider,
           slugProvider,
+          referralProvider,
           me: const UserId('me'),
         ),
       );

--- a/test/unit/chat_reply_message_test.dart
+++ b/test/unit/chat_reply_message_test.dart
@@ -48,6 +48,7 @@ import 'package:messenger/provider/drift/geolocation.dart';
 import 'package:messenger/provider/drift/locks.dart';
 import 'package:messenger/provider/drift/monolog.dart';
 import 'package:messenger/provider/drift/my_user.dart';
+import 'package:messenger/provider/drift/referrals.dart';
 import 'package:messenger/provider/drift/secret.dart';
 import 'package:messenger/provider/drift/session.dart';
 import 'package:messenger/provider/drift/settings.dart';
@@ -97,6 +98,7 @@ void main() async {
   final locksProvider = Get.put(LockDriftProvider(common));
   final secretsProvider = Get.put(RefreshSecretDriftProvider(common));
   final slugProvider = Get.put(SlugDriftProvider(common));
+  final referralProvider = Get.put(ReferralDriftProvider(common));
   final sessionProvider = Get.put(SessionDriftProvider(common, scoped));
   final geoProvider = Get.put(GeoLocationDriftProvider(common));
 
@@ -364,6 +366,7 @@ void main() async {
         versionProvider,
         monologProvider,
         slugProvider,
+        referralProvider,
         me: const UserId('08164fb1-ff60-49f6-8ff2-7fede51c3aed'),
       ),
     );
@@ -511,6 +514,7 @@ void main() async {
           versionProvider,
           monologProvider,
           slugProvider,
+          referralProvider,
           me: const UserId('08164fb1-ff60-49f6-8ff2-7fede51c3aed'),
         ),
       );

--- a/test/unit/chat_split_message_test.dart
+++ b/test/unit/chat_split_message_test.dart
@@ -48,6 +48,7 @@ import 'package:messenger/provider/drift/drift.dart';
 import 'package:messenger/provider/drift/locks.dart';
 import 'package:messenger/provider/drift/monolog.dart';
 import 'package:messenger/provider/drift/my_user.dart';
+import 'package:messenger/provider/drift/referrals.dart';
 import 'package:messenger/provider/drift/secret.dart';
 import 'package:messenger/provider/drift/settings.dart';
 import 'package:messenger/provider/drift/slugs.dart';
@@ -108,6 +109,7 @@ void main() async {
   final locksProvider = Get.put(LockDriftProvider(common));
   final secretsProvider = Get.put(RefreshSecretDriftProvider(common));
   final slugProvider = Get.put(SlugDriftProvider(common));
+  final referralProvider = Get.put(ReferralDriftProvider(common));
 
   AuthService authService = Get.put(
     AuthService(
@@ -282,6 +284,7 @@ void main() async {
         sessionProvider,
         monologProvider,
         slugProvider,
+        referralProvider,
         me: const UserId('me'),
       ),
     );
@@ -369,6 +372,7 @@ void main() async {
         sessionProvider,
         monologProvider,
         slugProvider,
+        referralProvider,
         me: const UserId('me'),
       ),
     );
@@ -467,6 +471,7 @@ void main() async {
           sessionProvider,
           monologProvider,
           slugProvider,
+          referralProvider,
           me: const UserId('me'),
         ),
       );
@@ -560,6 +565,7 @@ void main() async {
           sessionProvider,
           monologProvider,
           slugProvider,
+          referralProvider,
           me: const UserId('me'),
         ),
       );
@@ -642,6 +648,7 @@ void main() async {
         sessionProvider,
         monologProvider,
         slugProvider,
+        referralProvider,
         me: const UserId('me'),
       ),
     );
@@ -738,6 +745,7 @@ void main() async {
           sessionProvider,
           monologProvider,
           slugProvider,
+          referralProvider,
           me: const UserId('me'),
         ),
       );

--- a/test/unit/toggle_chat_mute_test.dart
+++ b/test/unit/toggle_chat_mute_test.dart
@@ -41,6 +41,7 @@ import 'package:messenger/provider/drift/drift.dart';
 import 'package:messenger/provider/drift/locks.dart';
 import 'package:messenger/provider/drift/monolog.dart';
 import 'package:messenger/provider/drift/my_user.dart';
+import 'package:messenger/provider/drift/referrals.dart';
 import 'package:messenger/provider/drift/secret.dart';
 import 'package:messenger/provider/drift/settings.dart';
 import 'package:messenger/provider/drift/slugs.dart';
@@ -93,6 +94,7 @@ void main() async {
   final locksProvider = Get.put(LockDriftProvider(common));
   final secretsProvider = Get.put(RefreshSecretDriftProvider(common));
   final slugProvider = Get.put(SlugDriftProvider(common));
+  final referralProvider = Get.put(ReferralDriftProvider(common));
 
   when(graphQlProvider.disconnect()).thenAnswer((_) => () {});
 
@@ -258,6 +260,7 @@ void main() async {
         sessionProvider,
         monologProvider,
         slugProvider,
+        referralProvider,
         me: const UserId('me'),
       ),
     );
@@ -339,6 +342,7 @@ void main() async {
           sessionProvider,
           monologProvider,
           slugProvider,
+          referralProvider,
           me: const UserId('me'),
         ),
       );

--- a/test/widget/chat_attachment_test.dart
+++ b/test/widget/chat_attachment_test.dart
@@ -66,6 +66,7 @@ import 'package:messenger/provider/drift/geolocation.dart';
 import 'package:messenger/provider/drift/locks.dart';
 import 'package:messenger/provider/drift/monolog.dart';
 import 'package:messenger/provider/drift/my_user.dart';
+import 'package:messenger/provider/drift/referrals.dart';
 import 'package:messenger/provider/drift/secret.dart';
 import 'package:messenger/provider/drift/session.dart';
 import 'package:messenger/provider/drift/settings.dart';
@@ -450,6 +451,7 @@ void main() async {
   final slugProvider = Get.put(SlugDriftProvider(common));
   final sessionProvider = Get.put(SessionDriftProvider(common, scoped));
   final geoProvider = Get.put(GeoLocationDriftProvider(common));
+  final referralProvider = Get.put(ReferralDriftProvider(common));
 
   Widget createWidgetForTesting({required Widget child}) {
     return MaterialApp(
@@ -531,6 +533,7 @@ void main() async {
             versionProvider,
             monologProvider,
             slugProvider,
+            referralProvider,
             me: const UserId('me'),
           ),
         );

--- a/test/widget/chat_edit_message_test.dart
+++ b/test/widget/chat_edit_message_test.dart
@@ -64,6 +64,7 @@ import 'package:messenger/provider/drift/geolocation.dart';
 import 'package:messenger/provider/drift/locks.dart';
 import 'package:messenger/provider/drift/monolog.dart';
 import 'package:messenger/provider/drift/my_user.dart';
+import 'package:messenger/provider/drift/referrals.dart';
 import 'package:messenger/provider/drift/secret.dart';
 import 'package:messenger/provider/drift/session.dart';
 import 'package:messenger/provider/drift/settings.dart';
@@ -407,6 +408,7 @@ void main() async {
   final locksProvider = Get.put(LockDriftProvider(common));
   final secretsProvider = Get.put(RefreshSecretDriftProvider(common));
   final slugProvider = Get.put(SlugDriftProvider(common));
+  final referralProvider = Get.put(ReferralDriftProvider(common));
   final sessionProvider = Get.put(SessionDriftProvider(common, scoped));
   final geoProvider = Get.put(GeoLocationDriftProvider(common));
 
@@ -489,6 +491,7 @@ void main() async {
         versionProvider,
         monologProvider,
         slugProvider,
+        referralProvider,
         me: const UserId('me'),
       ),
     );

--- a/test/widget/chat_hide_test.dart
+++ b/test/widget/chat_hide_test.dart
@@ -56,6 +56,7 @@ import 'package:messenger/provider/drift/geolocation.dart';
 import 'package:messenger/provider/drift/locks.dart';
 import 'package:messenger/provider/drift/monolog.dart';
 import 'package:messenger/provider/drift/my_user.dart';
+import 'package:messenger/provider/drift/referrals.dart';
 import 'package:messenger/provider/drift/secret.dart';
 import 'package:messenger/provider/drift/session.dart';
 import 'package:messenger/provider/drift/settings.dart';
@@ -117,6 +118,7 @@ void main() async {
   final locksProvider = Get.put(LockDriftProvider(common));
   final secretsProvider = Get.put(RefreshSecretDriftProvider(common));
   final slugProvider = Get.put(SlugDriftProvider(common));
+  final referralProvider = Get.put(ReferralDriftProvider(common));
 
   var graphQlProvider = MockGraphQlProvider();
   when(graphQlProvider.connected).thenReturn(RxBool(true));
@@ -442,6 +444,7 @@ void main() async {
         versionProvider,
         monologProvider,
         slugProvider,
+        referralProvider,
         me: const UserId('me'),
       ),
     );

--- a/test/widget/chat_rename_test.dart
+++ b/test/widget/chat_rename_test.dart
@@ -54,6 +54,7 @@ import 'package:messenger/provider/drift/drift.dart';
 import 'package:messenger/provider/drift/locks.dart';
 import 'package:messenger/provider/drift/monolog.dart';
 import 'package:messenger/provider/drift/my_user.dart';
+import 'package:messenger/provider/drift/referrals.dart';
 import 'package:messenger/provider/drift/secret.dart';
 import 'package:messenger/provider/drift/settings.dart';
 import 'package:messenger/provider/drift/slugs.dart';
@@ -97,6 +98,7 @@ void main() async {
   final locksProvider = Get.put(LockDriftProvider(common));
   final secretsProvider = Get.put(RefreshSecretDriftProvider(common));
   final slugProvider = Get.put(SlugDriftProvider(common));
+  final referralProvider = Get.put(ReferralDriftProvider(common));
 
   await accountProvider.upsert(const UserId('me'));
   await credentialsProvider.upsert(
@@ -428,6 +430,7 @@ void main() async {
         versionProvider,
         monologProvider,
         slugProvider,
+        referralProvider,
         me: const UserId('me'),
       ),
     );

--- a/test/widget/chat_reply_message_test.dart
+++ b/test/widget/chat_reply_message_test.dart
@@ -62,6 +62,7 @@ import 'package:messenger/provider/drift/geolocation.dart';
 import 'package:messenger/provider/drift/locks.dart';
 import 'package:messenger/provider/drift/monolog.dart';
 import 'package:messenger/provider/drift/my_user.dart';
+import 'package:messenger/provider/drift/referrals.dart';
 import 'package:messenger/provider/drift/secret.dart';
 import 'package:messenger/provider/drift/session.dart';
 import 'package:messenger/provider/drift/settings.dart';
@@ -450,6 +451,7 @@ void main() async {
   final locksProvider = Get.put(LockDriftProvider(common));
   final secretsProvider = Get.put(RefreshSecretDriftProvider(common));
   final slugProvider = Get.put(SlugDriftProvider(common));
+  final referralProvider = Get.put(ReferralDriftProvider(common));
   final sessionProvider = Get.put(SessionDriftProvider(common, scoped));
   final geoProvider = Get.put(GeoLocationDriftProvider(common));
 
@@ -553,6 +555,7 @@ void main() async {
             versionProvider,
             monologProvider,
             slugProvider,
+            referralProvider,
             me: const UserId('me'),
           ),
         );

--- a/test/widget/chat_update_attachments_test.dart
+++ b/test/widget/chat_update_attachments_test.dart
@@ -67,6 +67,7 @@ import 'package:messenger/provider/drift/geolocation.dart';
 import 'package:messenger/provider/drift/locks.dart';
 import 'package:messenger/provider/drift/monolog.dart';
 import 'package:messenger/provider/drift/my_user.dart';
+import 'package:messenger/provider/drift/referrals.dart';
 import 'package:messenger/provider/drift/secret.dart';
 import 'package:messenger/provider/drift/session.dart';
 import 'package:messenger/provider/drift/settings.dart';
@@ -455,6 +456,7 @@ void main() async {
   final locksProvider = Get.put(LockDriftProvider(common));
   final secretsProvider = Get.put(RefreshSecretDriftProvider(common));
   final slugProvider = Get.put(SlugDriftProvider(common));
+  final referralProvider = Get.put(ReferralDriftProvider(common));
   final sessionProvider = Get.put(SessionDriftProvider(common, scoped));
   final geoProvider = Get.put(GeoLocationDriftProvider(common));
 
@@ -542,6 +544,7 @@ void main() async {
         versionProvider,
         monologProvider,
         slugProvider,
+        referralProvider,
         me: const UserId('me'),
       ),
     );

--- a/test/widget/user_profile_test.dart
+++ b/test/widget/user_profile_test.dart
@@ -53,6 +53,7 @@ import 'package:messenger/provider/drift/geolocation.dart';
 import 'package:messenger/provider/drift/locks.dart';
 import 'package:messenger/provider/drift/monolog.dart';
 import 'package:messenger/provider/drift/my_user.dart';
+import 'package:messenger/provider/drift/referrals.dart';
 import 'package:messenger/provider/drift/secret.dart';
 import 'package:messenger/provider/drift/session.dart';
 import 'package:messenger/provider/drift/settings.dart';
@@ -97,6 +98,7 @@ void main() async {
   final locksProvider = Get.put(LockDriftProvider(common));
   final secretsProvider = Get.put(RefreshSecretDriftProvider(common));
   final slugProvider = Get.put(SlugDriftProvider(common));
+  final referralProvider = Get.put(ReferralDriftProvider(common));
 
   await accountProvider.upsert(const UserId('me'));
 
@@ -421,6 +423,7 @@ void main() async {
           versionProvider,
           monologProvider,
           slugProvider,
+          referralProvider,
           me: const UserId('me'),
         ),
       );


### PR DESCRIPTION
## Synopsis

`UserId`s who referred someone to a `Chat` or a `User` should be kept in a separate table to be used during `Chat` being created.




## Solution

This PR implements the specified behaviour by introducing a separate table used in `ChatRepository`.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://github.com/tapopa/messenger/blob/main/CONTRIBUTING.md#code-style
[l:3]: https://github.com/tapopa/messenger/blob/main/CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
