### PR TITLE
Redesign searching and reverse order of `Operation`s on `WalletTransactions` page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ All user visible changes to this project will be documented in this file. This p
 
 
 
+## [0.4.2] · 2026-??-??
+[0.4.2]: /../../tree/v0.4.2
+
+[Diff](/../../compare/v0.4.1...v0.4.2) | [Milestone](/../../milestone/14)
+
+### Changed
+
+- UI:
+    - Wallet tab:
+        - Searching and transactions order on transactions page. ([#54])
+
+[#54]: /../../pull/54
+
+
+
+
 ## [0.4.1] · 2026-04-08
 [0.4.1]: /../../tree/v0.4.1
 

--- a/assets/l10n/ru-RU.ftl
+++ b/assets/l10n/ru-RU.ftl
@@ -1291,7 +1291,7 @@ label_promotional_program_promo_plus = Промоутерская програм
 label_promotional_program_promo_plus_description1 = Пользователь{" "}
 label_promotional_program_promo_plus_description2 = {$user}
 label_promotional_program_promo_plus_description3 =
-    {" "}предлагает Вам {$percent} от планых сообщений, платных звонков и донатов, совершённых приглашёнными Вами пользователями.
+    {" "}предлагает Вам {$percent} от платных сообщений, платных звонков и донатов, совершённых приглашёнными Вами пользователями.
 
     {""}
 label_promotional_program_promo_plus_description4 = Промоутерский процент Promo+

--- a/helm/tapopa-messenger/Chart.yaml
+++ b/helm/tapopa-messenger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tapopa-messenger
 description: Messenger by Tapopa.
 version: 0.1.2
-appVersion: 0.4.1
+appVersion: 0.4.2
 type: application
 sources:
   - https://github.com/tapopa/messenger

--- a/lib/ui/page/home/page/partner_transactions/view.dart
+++ b/lib/ui/page/home/page/partner_transactions/view.dart
@@ -43,103 +43,13 @@ class PartnerTransactionsView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final style = Theme.of(context).style;
-
     return GetBuilder(
       init: PartnerTransactionsController(Get.find(), Get.find()),
       builder: (PartnerTransactionsController c) {
         return Scaffold(
           appBar: PreferredSize(
             preferredSize: Size(double.infinity, CustomAppBar.height),
-            child: Obx(() {
-              final Widget child;
-
-              if (c.searching.value) {
-                child = CustomAppBar(
-                  key: const Key('Search'),
-                  border: Border.all(color: style.colors.primary, width: 2),
-                  title: Row(
-                    children: [
-                      const SizedBox(width: 16),
-                      const SvgIcon(SvgIcons.search),
-                      Expanded(
-                        child: Theme(
-                          data: MessageFieldView.theme(context),
-                          child: ReactiveTextField(
-                            dense: true,
-                            state: c.search,
-                            hint: 'label_search'.l10n,
-                            style: style.fonts.medium.regular.onBackground,
-                            onChanged: () {
-                              c.query.value = c.search.text.isEmpty
-                                  ? null
-                                  : c.search.text;
-                            },
-                          ),
-                        ),
-                      ),
-                      WidgetButton(
-                        onPressed: c.toggleSearch,
-                        child: Padding(
-                          padding: const EdgeInsets.fromLTRB(8, 16, 16, 16),
-                          child: const SvgIcon(SvgIcons.closePrimary),
-                        ),
-                      ),
-                    ],
-                  ),
-                );
-              } else {
-                child = CustomAppBar(
-                  leading: const [SizedBox(width: 4), StyledBackButton()],
-                  title: Text('label_your_transactions'.l10n),
-                  actions: [
-                    ContextMenuRegion(
-                      enablePrimaryTap: true,
-                      enableLongTap: false,
-                      enableSecondaryTap: false,
-                      actions: [
-                        if (c.expanded.value)
-                          ContextMenuButton(
-                            label: 'btn_collapse_all'.l10n,
-                            trailing: SvgIcon(SvgIcons.viewFull),
-                            inverted: SvgIcon(SvgIcons.viewFullWhite),
-                            onPressed: () {
-                              c.expanded.toggle();
-                              c.ids.clear();
-                            },
-                          )
-                        else
-                          ContextMenuButton(
-                            label: 'btn_expand_all'.l10n,
-                            trailing: SvgIcon(SvgIcons.viewShort),
-                            inverted: SvgIcon(SvgIcons.viewShortWhite),
-                            onPressed: () {
-                              c.expanded.toggle();
-                              c.ids.clear();
-                            },
-                          ),
-                        ContextMenuButton(
-                          label: 'btn_search'.l10n,
-                          trailing: SvgIcon(SvgIcons.search),
-                          inverted: SvgIcon(SvgIcons.searchWhite),
-                          onPressed: c.toggleSearch,
-                        ),
-                      ],
-                      child: Padding(
-                        padding: const EdgeInsets.fromLTRB(16, 8, 20, 8),
-                        child: SvgIcon(SvgIcons.more),
-                      ),
-                    ),
-                  ],
-                );
-              }
-
-              return AnimatedSizeAndFade(
-                fadeDuration: const Duration(milliseconds: 250),
-                sizeDuration: const Duration(milliseconds: 250),
-                child: child,
-              );
-            }),
+            child: _bar(context, c),
           ),
           body: Column(
             children: [
@@ -231,6 +141,101 @@ class PartnerTransactionsView extends StatelessWidget {
         );
       },
     );
+  }
+
+  /// Builds the contents of an [AppBar].
+  Widget _bar(BuildContext context, PartnerTransactionsController c) {
+    final style = Theme.of(context).style;
+
+    return Obx(() {
+      final Widget child;
+
+      if (c.searching.value) {
+        child = CustomAppBar(
+          key: const Key('Search'),
+          border: Border.all(color: style.colors.primary, width: 2),
+          title: Row(
+            children: [
+              const SizedBox(width: 16),
+              const SvgIcon(SvgIcons.search),
+              Expanded(
+                child: Theme(
+                  data: MessageFieldView.theme(context),
+                  child: ReactiveTextField(
+                    dense: true,
+                    state: c.search,
+                    hint: 'label_search'.l10n,
+                    style: style.fonts.medium.regular.onBackground,
+                    onChanged: () {
+                      c.query.value = c.search.text.isEmpty
+                          ? null
+                          : c.search.text;
+                    },
+                  ),
+                ),
+              ),
+              WidgetButton(
+                onPressed: c.toggleSearch,
+                child: Padding(
+                  padding: const EdgeInsets.fromLTRB(8, 16, 16, 16),
+                  child: const SvgIcon(SvgIcons.closePrimary),
+                ),
+              ),
+            ],
+          ),
+        );
+      } else {
+        child = CustomAppBar(
+          leading: const [SizedBox(width: 4), StyledBackButton()],
+          title: Text('label_your_transactions'.l10n),
+          actions: [
+            ContextMenuRegion(
+              enablePrimaryTap: true,
+              enableLongTap: false,
+              enableSecondaryTap: false,
+              actions: [
+                if (c.expanded.value)
+                  ContextMenuButton(
+                    label: 'btn_collapse_all'.l10n,
+                    trailing: SvgIcon(SvgIcons.viewFull),
+                    inverted: SvgIcon(SvgIcons.viewFullWhite),
+                    onPressed: () {
+                      c.expanded.toggle();
+                      c.ids.clear();
+                    },
+                  )
+                else
+                  ContextMenuButton(
+                    label: 'btn_expand_all'.l10n,
+                    trailing: SvgIcon(SvgIcons.viewShort),
+                    inverted: SvgIcon(SvgIcons.viewShortWhite),
+                    onPressed: () {
+                      c.expanded.toggle();
+                      c.ids.clear();
+                    },
+                  ),
+                ContextMenuButton(
+                  label: 'btn_search'.l10n,
+                  trailing: SvgIcon(SvgIcons.search),
+                  inverted: SvgIcon(SvgIcons.searchWhite),
+                  onPressed: c.toggleSearch,
+                ),
+              ],
+              child: Padding(
+                padding: const EdgeInsets.fromLTRB(16, 8, 20, 8),
+                child: SvgIcon(SvgIcons.more),
+              ),
+            ),
+          ],
+        );
+      }
+
+      return AnimatedSizeAndFade(
+        fadeDuration: const Duration(milliseconds: 250),
+        sizeDuration: const Duration(milliseconds: 250),
+        child: child,
+      );
+    });
   }
 
   /// Returns [Container] displaying available and hold [Balance]s.

--- a/lib/ui/page/home/page/user/view.dart
+++ b/lib/ui/page/home/page/user/view.dart
@@ -709,15 +709,17 @@ class UserView extends StatelessWidget {
       padding: Block.defaultPadding.copyWith(right: 0, left: 0),
       children: [
         Obx(() {
-          return IgnorePointer(
-            ignoring: c.isSupport,
-            child: DirectLinkField(
-              c.links.values,
-              onAdded: c.linkLink,
-              onRemoved: c.unlinkLink,
-              onMore: c.links.hasNext.value && !c.links.nextLoading.value
-                  ? c.links.next
-                  : null,
+          return SelectionContainer.disabled(
+            child: IgnorePointer(
+              ignoring: c.isSupport,
+              child: DirectLinkField(
+                c.links.values,
+                onAdded: c.linkLink,
+                onRemoved: c.unlinkLink,
+                onMore: c.links.hasNext.value && !c.links.nextLoading.value
+                    ? c.links.next
+                    : null,
+              ),
             ),
           );
         }),

--- a/lib/ui/page/home/page/wallet_transactions/controller.dart
+++ b/lib/ui/page/home/page/wallet_transactions/controller.dart
@@ -38,6 +38,9 @@ class WalletTransactionsController extends GetxController {
   /// [OperationId]s of the [Operation]s that are should be expanded only.
   final RxSet<OperationId> ids = RxSet();
 
+  /// Indicator whether searching is toggled on or off.
+  final RxBool searching = RxBool(false);
+
   /// [TextFieldState] of a search field for filtering the [operations].
   final TextFieldState search = TextFieldState();
 
@@ -93,6 +96,14 @@ class WalletTransactionsController extends GetxController {
 
   /// Returns a reactive [User] from [UserService] by the provided [id].
   FutureOr<RxUser?> getUser(UserId id) => _userService.get(id);
+
+  /// Toggles [searching] enabled and disabled.
+  void toggleSearch([bool? enabled]) {
+    enabled ??= searching.value;
+    searching.value = !enabled;
+    search.clear();
+    query.value = null;
+  }
 
   /// Requests the next page of [Operation]s based on the
   /// [ScrollController.position] value.

--- a/lib/ui/page/home/page/wallet_transactions/view.dart
+++ b/lib/ui/page/home/page/wallet_transactions/view.dart
@@ -15,6 +15,7 @@
 // along with this program. If not, see
 // <https://www.gnu.org/licenses/agpl-3.0.html>.
 
+import 'package:animated_size_and_fade/animated_size_and_fade.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
@@ -25,7 +26,8 @@ import '/ui/page/home/page/chat/message_field/view.dart';
 import '/ui/page/home/page/chat/widget/back_button.dart';
 import '/ui/page/home/widget/app_bar.dart';
 import '/ui/page/home/widget/operation.dart';
-import '/ui/widget/animated_button.dart';
+import '/ui/widget/context_menu/menu.dart';
+import '/ui/widget/context_menu/region.dart';
 import '/ui/widget/progress_indicator.dart';
 import '/ui/widget/svg/svg.dart';
 import '/ui/widget/text_field.dart';
@@ -42,133 +44,174 @@ class WalletTransactionsView extends StatelessWidget {
       init: WalletTransactionsController(Get.find(), Get.find()),
       builder: (WalletTransactionsController c) {
         return Scaffold(
-          appBar: CustomAppBar(
-            leading: const [SizedBox(width: 4), StyledBackButton()],
-            title: Text('label_your_transactions'.l10n),
-            actions: [
-              AnimatedButton(
-                onPressed: () {
-                  c.expanded.toggle();
-                  c.ids.clear();
-                },
-                decorator: (child) => Padding(
-                  padding: const EdgeInsets.fromLTRB(12, 8, 20, 8),
-                  child: child,
-                ),
-                child: Padding(
-                  padding: const EdgeInsets.fromLTRB(8, 4, 0, 4),
-                  child: Obx(() {
-                    return SvgIcon(
-                      c.expanded.value ? SvgIcons.viewFull : SvgIcons.viewShort,
-                    );
-                  }),
-                ),
-              ),
-            ],
+          appBar: PreferredSize(
+            preferredSize: Size(double.infinity, CustomAppBar.height),
+            child: _bar(context, c),
           ),
-          body: Column(
-            children: [
-              Expanded(
-                child: Obx(() {
-                  return ListView.builder(
-                    controller: c.scrollController,
-                    reverse: true,
-                    padding: EdgeInsets.fromLTRB(0, 8, 0, 8),
-                    itemCount: c.operations.length,
-                    itemBuilder: (context, i) {
-                      final Rx<Operation> e = c.operations.values.elementAt(i);
+          body: Obx(() {
+            Iterable<Rx<Operation>> filtered = c.operations.values;
 
-                      final Widget child = Center(
-                        child: ConstrainedBox(
-                          constraints: BoxConstraints(maxWidth: 400),
-                          child: Padding(
-                            padding: const EdgeInsets.fromLTRB(10, 3, 10, 3),
-                            child: WidgetButton(
-                              onPressed: () {
-                                if (c.ids.contains(e.value.id)) {
-                                  c.ids.remove(e.value.id);
-                                } else {
-                                  c.ids.add(e.value.id);
-                                }
-                              },
-                              child: Obx(() {
-                                final bool expanded = c.expanded.value;
+            final String? query = c.query.value;
 
-                                return OperationWidget(
-                                  e.value,
-                                  expanded:
-                                      (expanded &&
-                                          !c.ids.contains(e.value.id)) ||
-                                      (!expanded && c.ids.contains(e.value.id)),
-                                  getUser: c.getUser,
-                                );
-                              }),
-                            ),
-                          ),
-                        ),
-                      );
+            if (query != null && query.isNotEmpty) {
+              filtered = filtered.where((e) {
+                final Operation operation = e.value;
 
-                      if (i == c.operations.length - 1) {
-                        return Column(
-                          children: [
-                            if (c.hasNext.value) ...[
-                              const SizedBox(height: 8),
-                              const CustomProgressIndicator.small(),
-                              const SizedBox(height: 8),
-                            ],
-                            child,
-                          ],
-                        );
-                      }
+                return query.contains(operation.id.val) ||
+                    query.contains(operation.num.toString());
+              });
+            }
 
-                      return child;
-                    },
+            return ListView.builder(
+              controller: c.scrollController,
+              padding: EdgeInsets.fromLTRB(0, 8, 0, 8),
+              itemCount: filtered.length,
+              itemBuilder: (context, i) {
+                final Rx<Operation> e = filtered.elementAt(i);
+
+                final Widget child = Center(
+                  child: ConstrainedBox(
+                    constraints: BoxConstraints(maxWidth: 400),
+                    child: Padding(
+                      padding: const EdgeInsets.fromLTRB(10, 3, 10, 3),
+                      child: WidgetButton(
+                        onPressed: () {
+                          if (c.ids.contains(e.value.id)) {
+                            c.ids.remove(e.value.id);
+                          } else {
+                            c.ids.add(e.value.id);
+                          }
+                        },
+                        child: Obx(() {
+                          final bool expanded = c.expanded.value;
+
+                          return OperationWidget(
+                            e.value,
+                            expanded:
+                                (expanded && !c.ids.contains(e.value.id)) ||
+                                (!expanded && c.ids.contains(e.value.id)),
+                            getUser: c.getUser,
+                          );
+                        }),
+                      ),
+                    ),
+                  ),
+                );
+
+                if (i == c.operations.length - 1) {
+                  return Column(
+                    children: [
+                      if (c.hasNext.value) ...[
+                        const SizedBox(height: 8),
+                        const CustomProgressIndicator.small(),
+                        const SizedBox(height: 8),
+                      ],
+                      child,
+                    ],
                   );
-                }),
-              ),
-              _search(context, c),
-            ],
-          ),
+                }
+
+                return child;
+              },
+            );
+          }),
         );
       },
     );
   }
 
-  /// Returns the search field for transactions filtering.
-  Widget _search(BuildContext context, WalletTransactionsController c) {
+  /// Builds the contents of an [AppBar].
+  Widget _bar(BuildContext context, WalletTransactionsController c) {
     final style = Theme.of(context).style;
 
-    return Container(
-      decoration: BoxDecoration(
-        color: style.cardColor,
-        boxShadow: [
-          CustomBoxShadow(
-            blurRadius: 8,
-            color: style.colors.onBackgroundOpacity13,
+    return Obx(() {
+      final Widget child;
+
+      if (c.searching.value) {
+        child = CustomAppBar(
+          key: const Key('Search'),
+          border: Border.all(color: style.colors.primary, width: 2),
+          title: Row(
+            children: [
+              const SizedBox(width: 16),
+              const SvgIcon(SvgIcons.search),
+              Expanded(
+                child: Theme(
+                  data: MessageFieldView.theme(context),
+                  child: ReactiveTextField(
+                    dense: true,
+                    state: c.search,
+                    hint: 'label_search'.l10n,
+                    style: style.fonts.medium.regular.onBackground,
+                    onChanged: () {
+                      c.query.value = c.search.text.isEmpty
+                          ? null
+                          : c.search.text;
+                    },
+                  ),
+                ),
+              ),
+              WidgetButton(
+                onPressed: c.toggleSearch,
+                child: Padding(
+                  padding: const EdgeInsets.fromLTRB(8, 16, 16, 16),
+                  child: const SvgIcon(SvgIcons.closePrimary),
+                ),
+              ),
+            ],
           ),
-        ],
-      ),
-      constraints: const BoxConstraints(minHeight: 57),
-      child: Row(
-        children: [
-          const SizedBox(width: 16),
-          const SvgIcon(SvgIcons.search),
-          Expanded(
-            child: Theme(
-              data: MessageFieldView.theme(context),
-              child: ReactiveTextField(
-                dense: true,
-                state: c.search,
-                hint: 'label_search'.l10n,
-                style: style.fonts.medium.regular.onBackground,
-                onChanged: () {
-                  c.query.value = c.search.text.isEmpty ? null : c.search.text;
-                },
+        );
+      } else {
+        child = CustomAppBar(
+          leading: const [SizedBox(width: 4), StyledBackButton()],
+          title: Text('label_your_transactions'.l10n),
+          actions: [
+            ContextMenuRegion(
+              enablePrimaryTap: true,
+              enableLongTap: false,
+              enableSecondaryTap: false,
+              actions: [
+                if (c.expanded.value)
+                  ContextMenuButton(
+                    label: 'btn_collapse_all'.l10n,
+                    trailing: SvgIcon(SvgIcons.viewFull),
+                    inverted: SvgIcon(SvgIcons.viewFullWhite),
+                    onPressed: () {
+                      c.expanded.toggle();
+                      c.ids.clear();
+                    },
+                  )
+                else
+                  ContextMenuButton(
+                    label: 'btn_expand_all'.l10n,
+                    trailing: SvgIcon(SvgIcons.viewShort),
+                    inverted: SvgIcon(SvgIcons.viewShortWhite),
+                    onPressed: () {
+                      c.expanded.toggle();
+                      c.ids.clear();
+                    },
+                  ),
+                ContextMenuButton(
+                  label: 'btn_search'.l10n,
+                  trailing: SvgIcon(SvgIcons.search),
+                  inverted: SvgIcon(SvgIcons.searchWhite),
+                  onPressed: c.toggleSearch,
+                ),
+              ],
+              child: Padding(
+                padding: const EdgeInsets.fromLTRB(16, 8, 20, 8),
+                child: SvgIcon(SvgIcons.more),
               ),
             ),
-          ),
-        ],
-      ),
-    );
+          ],
+        );
+      }
+
+      return AnimatedSizeAndFade(
+        fadeDuration: const Duration(milliseconds: 250),
+        sizeDuration: const Duration(milliseconds: 250),
+        child: child,
+      );
+    });
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: messenger
-version: 0.4.1
+version: 0.4.2
 publish_to: none
 
 environment:


### PR DESCRIPTION
## Synopsis

`WalletTransactions` has a few UI changes that must be accounted.




## Solution

This PR redesigns searching and changes the order of `Operation`s on `WalletTransactions` page.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://github.com/tapopa/messenger/blob/main/CONTRIBUTING.md#code-style
[l:3]: https://github.com/tapopa/messenger/blob/main/CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
