### PR TITLE
Use `onHeight` calculation on `Management` page to expand rows for long `DirectLinkSlug`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,14 @@ All user visible changes to this project will be documented in this file. This p
     - Wallet tab:
         - Payment card top up method. ([#59])
 
+### Fixed
+
+- UI:
+    - Links statistics page:
+        - Long links being clipped in table. ([#60])
+
 [#59]: /../../pull/59
+[#60]: /../../pull/60
 
 
 

--- a/lib/ui/page/home/page/management/view.dart
+++ b/lib/ui/page/home/page/management/view.dart
@@ -15,6 +15,8 @@
 // along with this program. If not, see
 // <https://www.gnu.org/licenses/agpl-3.0.html>.
 
+import 'dart:math';
+
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:share_plus/share_plus.dart';
@@ -89,7 +91,11 @@ class ManagementView extends StatelessWidget {
                   Expanded(
                     child: Padding(
                       padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
-                      child: _table(context, c),
+                      child: LayoutBuilder(
+                        builder: (context, constraints) {
+                          return _table(context, c, constraints);
+                        },
+                      ),
                     ),
                   ),
                 // const SizedBox(height: 16),
@@ -102,7 +108,11 @@ class ManagementView extends StatelessWidget {
   }
 
   /// Builds a [TableGrid] representing the [DirectLink]s.
-  Widget _table(BuildContext context, ManagementController c) {
+  Widget _table(
+    BuildContext context,
+    ManagementController c,
+    BoxConstraints constraints,
+  ) {
     final style = Theme.of(context).style;
 
     return Container(
@@ -158,6 +168,23 @@ class ManagementView extends StatelessWidget {
                       c.headers.insert(bIndex, c.headers.removeAt(aIndex));
                     }
                   }
+                },
+                onHeight: (i) {
+                  if (i == 0) {
+                    return 64;
+                  }
+
+                  final link = c.links.values.elementAtOrNull(i - 1);
+                  if (link == null) {
+                    return 64;
+                  }
+
+                  return max(
+                    64,
+                    16 *
+                        (9 * '${Config.link}${link.slug}'.length) /
+                        max(constraints.maxWidth * 0.25, 108),
+                  );
                 },
                 items: c.links.values,
                 builders: c.headers

--- a/lib/ui/page/home/page/management/widget/table_grid.dart
+++ b/lib/ui/page/home/page/management/widget/table_grid.dart
@@ -31,6 +31,7 @@ class TableGrid<E> extends StatefulWidget {
     this.verticalDetails = const ScrollableDetails.vertical(),
     this.indicateLoading = false,
     this.onReorder,
+    this.onHeight = _defaultHeight,
   });
 
   /// [TableBuilder] to build in the [TableView].
@@ -50,6 +51,12 @@ class TableGrid<E> extends StatefulWidget {
 
   /// Callback, called when the provided [TableBuilder]s are reordered.
   final void Function(TableBuilder<E>, TableBuilder<E>)? onReorder;
+
+  /// Function, returning height in pixels specific row should occupy.
+  final double Function(int) onHeight;
+
+  /// Returns hardcoded const 64 value.
+  static double _defaultHeight(int _) => 64;
 
   @override
   State<TableGrid<E>> createState() => _TableGridState<E>();
@@ -227,7 +234,7 @@ class _TableGridState<E> extends State<TableGrid<E>> {
           pinnedRowCount: 1,
           rowBuilder: (int index) {
             return Span(
-              extent: FixedSpanExtent(widget.builders[index].height),
+              extent: FixedSpanExtent(widget.onHeight(index)),
               foregroundDecoration: SpanDecoration(
                 border: SpanBorder(
                   trailing: BorderSide(
@@ -254,7 +261,6 @@ class TableBuilder<E> {
     required this.header,
     required this.builder,
     this.width = 1,
-    this.height = 64,
     this.identifier,
   });
 
@@ -269,9 +275,6 @@ class TableBuilder<E> {
 
   /// Width in flex units this column should occupy.
   final double width;
-
-  /// Height in pixels this row should occupy.
-  final double height;
 
   /// Meta information embedded into this [TableBuilder].
   final String? identifier;


### PR DESCRIPTION
## Synopsis

`Management` page contains a table of `DirectLink`s, and those links can have a lot of symbols in them. Currently the row's height is fixes, which can clip the link.




## Solution

This PR introduces a way to calculate each row individually for the table, so that it expands depending on some calculations.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://github.com/tapopa/messenger/blob/main/CONTRIBUTING.md#code-style
[l:3]: https://github.com/tapopa/messenger/blob/main/CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
