### PR TITLE
Use dynamic tags for `WebUtils.protect()` in `Wallet` and `Partner` stores temporary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ All user visible changes to this project will be documented in this file. This p
 
 - UI:
     - Home page:
-        - Display balances over wallet and monetization tab icons. ([#61])
+        - Display balances over wallet and monetization tab icons. ([#63], [#61])
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,10 +28,12 @@ All user visible changes to this project will be documented in this file. This p
 - UI:
     - Links statistics page:
         - Long links being clipped in table. ([#60])
+    - Balances not being updated when multiple instances of application are opened. ([#63])
 
 [#59]: /../../pull/59
 [#60]: /../../pull/60
 [#61]: /../../pull/61
+[#63]: /../../pull/63
 
 
 

--- a/lib/store/partner.dart
+++ b/lib/store/partner.dart
@@ -486,17 +486,23 @@ class PartnerRepository extends IdentityDependency
       return;
     }
 
-    await WebUtils.protect(() async {
-      if (me.isLocal || isClosed) {
-        return;
-      }
+    await WebUtils.protect(
+      () async {
+        if (me.isLocal || isClosed) {
+          return;
+        }
 
-      _availableSubscription = StreamQueue(
-        await _balanceUpdates(BalanceOrigin.incomeAvailable),
-      );
+        _availableSubscription = StreamQueue(
+          await _balanceUpdates(BalanceOrigin.incomeAvailable),
+        );
 
-      await _availableSubscription!.execute(_availableUpdate);
-    }, tag: 'availableUpdates()');
+        await _availableSubscription!.execute(_availableUpdate);
+      },
+
+      // TODO: Shouldn't do runtime tag, instead should be synchronized via
+      //       `drift` local subscription.
+      tag: 'availableUpdates(${DateTime.now()})',
+    );
   }
 
   /// Handles [BalanceUpdates] from the [_availableUpdate] subscription.
@@ -529,17 +535,23 @@ class PartnerRepository extends IdentityDependency
       return;
     }
 
-    await WebUtils.protect(() async {
-      if (me.isLocal || isClosed) {
-        return;
-      }
+    await WebUtils.protect(
+      () async {
+        if (me.isLocal || isClosed) {
+          return;
+        }
 
-      _holdSubscription = StreamQueue(
-        await _balanceUpdates(BalanceOrigin.incomeHold),
-      );
+        _holdSubscription = StreamQueue(
+          await _balanceUpdates(BalanceOrigin.incomeHold),
+        );
 
-      await _holdSubscription!.execute(_holdUpdate);
-    }, tag: 'holdUpdates()');
+        await _holdSubscription!.execute(_holdUpdate);
+      },
+
+      // TODO: Shouldn't do runtime tag, instead should be synchronized via
+      //       `drift` local subscription.
+      tag: 'holdUpdates(${DateTime.now()})',
+    );
   }
 
   /// Handles [BalanceUpdates] from the [_holdUpdate] subscription.
@@ -598,22 +610,28 @@ class PartnerRepository extends IdentityDependency
       return;
     }
 
-    await WebUtils.protect(() async {
-      if (me.isLocal || isClosed) {
-        return;
-      }
+    await WebUtils.protect(
+      () async {
+        if (me.isLocal || isClosed) {
+          return;
+        }
 
-      _operationsSubscription = StreamQueue(
-        await operationsEvents(
-          await _graphQlProvider.operationsEvents(
-            OperationOrigin.income,
-            null,
-            () => null,
+        _operationsSubscription = StreamQueue(
+          await operationsEvents(
+            await _graphQlProvider.operationsEvents(
+              OperationOrigin.income,
+              null,
+              () => null,
+            ),
           ),
-        ),
-      );
-      await _operationsSubscription!.execute(_operationsEvent);
-    }, tag: 'partner.operationsEvents()');
+        );
+        await _operationsSubscription!.execute(_operationsEvent);
+      },
+
+      // TODO: Shouldn't do runtime tag, instead should be synchronized via
+      //       `drift` local subscription.
+      tag: 'partner.operationsEvents(${DateTime.now()})',
+    );
   }
 
   /// Handles [OperationsEvents] from the [operationsEvents] subscription.
@@ -789,19 +807,25 @@ class PartnerRepository extends IdentityDependency
       return;
     }
 
-    await WebUtils.protect(() async {
-      if (me.isLocal || isClosed) {
-        return;
-      }
+    await WebUtils.protect(
+      () async {
+        if (me.isLocal || isClosed) {
+          return;
+        }
 
-      _myMonetizationSettingsSubscription = StreamQueue(
-        await _myMonetizationSettingsEvents(),
-      );
+        _myMonetizationSettingsSubscription = StreamQueue(
+          await _myMonetizationSettingsEvents(),
+        );
 
-      await _myMonetizationSettingsSubscription!.execute(
-        _myMonetizationSettingsEvent,
-      );
-    }, tag: 'myMonetizationSettingsEvents()');
+        await _myMonetizationSettingsSubscription!.execute(
+          _myMonetizationSettingsEvent,
+        );
+      },
+
+      // TODO: Shouldn't do runtime tag, instead should be synchronized via
+      //       `drift` local subscription.
+      tag: 'myMonetizationSettingsEvents(${DateTime.now()})',
+    );
   }
 
   /// Handles [MonetizationSettingsEvents].
@@ -1161,17 +1185,23 @@ class PartnerRepository extends IdentityDependency
       return;
     }
 
-    await WebUtils.protect(() async {
-      if (me.isLocal || isClosed) {
-        return;
-      }
+    await WebUtils.protect(
+      () async {
+        if (me.isLocal || isClosed) {
+          return;
+        }
 
-      _subscriptions.remove(id)?.close(immediate: true);
-      _subscriptions[id] = StreamQueue(await _monetizationSettingsEvents(id));
-      await _subscriptions[id]?.execute(
-        (e) => _monetizationSettingsEvent(e, id),
-      );
-    }, tag: 'monetizationSettingsEvents($id)');
+        _subscriptions.remove(id)?.close(immediate: true);
+        _subscriptions[id] = StreamQueue(await _monetizationSettingsEvents(id));
+        await _subscriptions[id]?.execute(
+          (e) => _monetizationSettingsEvent(e, id),
+        );
+      },
+
+      // TODO: Shouldn't do runtime tag, instead should be synchronized via
+      //       `drift` local subscription.
+      tag: 'monetizationSettingsEvents($id+${DateTime.now()})',
+    );
   }
 
   /// Returns a [Stream] of [MonetizationSettings] of the currently

--- a/lib/store/wallet.dart
+++ b/lib/store/wallet.dart
@@ -424,14 +424,20 @@ class WalletRepository extends IdentityDependency
       return;
     }
 
-    await WebUtils.protect(() async {
-      if (me.isLocal || isClosed) {
-        return;
-      }
+    await WebUtils.protect(
+      () async {
+        if (me.isLocal || isClosed) {
+          return;
+        }
 
-      _balanceSubscription = StreamQueue(await _balanceUpdates());
-      await _balanceSubscription!.execute(_balanceUpdate);
-    }, tag: 'balanceUpdates()');
+        _balanceSubscription = StreamQueue(await _balanceUpdates());
+        await _balanceSubscription!.execute(_balanceUpdate);
+      },
+
+      // TODO: Shouldn't do runtime tag, instead should be synchronized via
+      //       `drift` local subscription.
+      tag: 'balanceUpdates(${DateTime.now()})',
+    );
   }
 
   /// Returns a [Stream] of [Balance]s of the specified [MyUser]'s purse.
@@ -490,22 +496,28 @@ class WalletRepository extends IdentityDependency
       return;
     }
 
-    await WebUtils.protect(() async {
-      if (me.isLocal || isClosed) {
-        return;
-      }
+    await WebUtils.protect(
+      () async {
+        if (me.isLocal || isClosed) {
+          return;
+        }
 
-      _operationsSubscription = StreamQueue(
-        await operationsEvents(
-          await _graphQlProvider.operationsEvents(
-            OperationOrigin.purse,
-            null,
-            () => null,
+        _operationsSubscription = StreamQueue(
+          await operationsEvents(
+            await _graphQlProvider.operationsEvents(
+              OperationOrigin.purse,
+              null,
+              () => null,
+            ),
           ),
-        ),
-      );
-      await _operationsSubscription!.execute(_operationsEvent);
-    }, tag: 'wallet.operationsEvents()');
+        );
+        await _operationsSubscription!.execute(_operationsEvent);
+      },
+
+      // TODO: Shouldn't do runtime tag, instead should be synchronized via
+      //       `drift` local subscription.
+      tag: 'wallet.operationsEvents(${DateTime.now()})',
+    );
   }
 
   /// Handles [OperationsEvents] from the [operationsEvents] subscription.

--- a/lib/ui/page/home/widget/partner_icon.dart
+++ b/lib/ui/page/home/widget/partner_icon.dart
@@ -62,14 +62,11 @@ class PartnerIcon extends StatelessWidget {
       overlay = const SizedBox();
     }
 
-    return Transform.translate(
-      offset: Offset(0, -1 + (value ?? 0) > 0 ? -2 : 0),
-      child: Stack(
-        children: [
-          icon,
-          Positioned.fill(child: Center(child: overlay)),
-        ],
-      ),
+    return Stack(
+      children: [
+        icon,
+        Positioned.fill(child: Center(child: overlay)),
+      ],
     );
   }
 

--- a/lib/ui/page/home/widget/wallet_icon.dart
+++ b/lib/ui/page/home/widget/wallet_icon.dart
@@ -62,14 +62,11 @@ class WalletIcon extends StatelessWidget {
       overlay = const SizedBox();
     }
 
-    return Transform.translate(
-      offset: Offset(0, -1 + (balance ?? 0) > 0 ? -2 : 0),
-      child: Stack(
-        children: [
-          icon,
-          Positioned.fill(child: Center(child: overlay)),
-        ],
-      ),
+    return Stack(
+      children: [
+        icon,
+        Positioned.fill(child: Center(child: overlay)),
+      ],
     );
   }
 


### PR DESCRIPTION
## Synopsis

`WebUtils.protect()` protects critical sections from being executed under different tabs in browser. However, since some `Wallet` and `Partner` related subscriptions aren't locally stored currently, this leads to a bug of balances never loading for multiple tabs.




## Solution

This PR fixes the bug by using the dynamic tags in such cases, so that multiple subscriptions can run simultaneously.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [ ] [Review][l:4] is completed and changes are approved
    - [ ] FCM (final commit message) is approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://github.com/tapopa/messenger/blob/main/CONTRIBUTING.md#code-style
[l:3]: https://github.com/tapopa/messenger/blob/main/CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
